### PR TITLE
Endpoint updates

### DIFF
--- a/src/main/java/com/zero5nelsonm/lendr/config/SimpleCorsFilter.java
+++ b/src/main/java/com/zero5nelsonm/lendr/config/SimpleCorsFilter.java
@@ -23,16 +23,12 @@ public class SimpleCorsFilter implements Filter {
                          FilterChain chain) throws IOException, ServletException {
         HttpServletResponse response = (HttpServletResponse) res;
         HttpServletRequest request = (HttpServletRequest) req;
-        response.setHeader("Access-Control-Allow-Origin",
-                "*");
-        //        response.setHeader("Access-Control-Allow-Methods", "POST, PUT, GET, OPTIONS, DELETE");
-        response.setHeader("Access-Control-Allow-Methods",
-                "*");
-        //        response.setHeader("Access-Control-Allow-Headers", "x-requested-with, authorization, content-type, access_token");
-        response.setHeader("Access-Control-Allow-Headers",
-                "*");
-        response.setHeader("Access-Control-Max-Age",
-                "3600");
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.setHeader("Access-Control-Allow-Methods", "POST, PUT, GET, OPTIONS, DELETE");
+        //response.setHeader("Access-Control-Allow-Methods", "*");
+        response.setHeader("Access-Control-Allow-Headers", "x-requested-with, authorization, content-type, access_token");
+        //response.setHeader("Access-Control-Allow-Headers", "*");
+        response.setHeader("Access-Control-Max-Age", "3600");
 
         if (HttpMethod.OPTIONS.name()
                 .equalsIgnoreCase(((HttpServletRequest) req).getMethod())) {

--- a/src/main/java/com/zero5nelsonm/lendr/controllers/ItemController.java
+++ b/src/main/java/com/zero5nelsonm/lendr/controllers/ItemController.java
@@ -104,4 +104,18 @@ public class ItemController {
 
         return new ResponseEntity<>(responseHeaders, HttpStatus.CREATED);
     }
+
+    @PutMapping(value = "/item/{itemid}", consumes = {"application/json"})
+    public ResponseEntity<?> updateItem(HttpServletRequest request,
+                                        Authentication authentication,
+                                        @Valid @RequestBody Item updateItem,
+                                        @PathVariable long itemid) {
+
+        logger.trace(request.getMethod().toUpperCase() + " " + request.getRequestURI() + " accessed");
+
+        User u = userService.findByName(authentication.getName());
+
+        itemService.update(updateItem, itemid, u);
+        return  new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/zero5nelsonm/lendr/controllers/ItemController.java
+++ b/src/main/java/com/zero5nelsonm/lendr/controllers/ItemController.java
@@ -118,4 +118,17 @@ public class ItemController {
         itemService.update(updateItem, itemid, u);
         return  new ResponseEntity<>(HttpStatus.OK);
     }
+
+    @DeleteMapping(value = "item/{itemid}")
+    public ResponseEntity<?> deleteItemById(HttpServletRequest request,
+                                            Authentication authentication,
+                                            @PathVariable long itemid) {
+
+        logger.trace(request.getMethod().toUpperCase() + " " + request.getRequestURI() + " accessed");
+
+        User u = userService.findByName(authentication.getName());
+
+        itemService.delete(u, itemid);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/zero5nelsonm/lendr/model/ItemNoHistory.java
+++ b/src/main/java/com/zero5nelsonm/lendr/model/ItemNoHistory.java
@@ -1,56 +1,30 @@
 package com.zero5nelsonm.lendr.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.zero5nelsonm.lendr.logging.Loggable;
-import io.swagger.annotations.ApiModel;
-
-import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
-@Loggable
-@Entity
-@Table(name = "items", uniqueConstraints = {@UniqueConstraint(columnNames = {"userid", "itemname"})})
-@ApiModel(value = "Item", description = "A list of items for the user")
-@JsonIgnoreProperties("user")
-public class Item extends Auditable {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+public class ItemNoHistory {
     private long itemid;
-
-    @Column(nullable = false)
     private String itemname;
-
     private String itemdescription;
     private String lentto;
     private String lentdate;
     private String lendnotes;
+    private List<ItemHistory> itemhistories;
 
-    @ManyToOne
-    @JoinColumn(name = "userid", nullable = false)
-    @JsonIgnoreProperties("useritems")
-    private User user;
-
-    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
-    @JsonIgnoreProperties("item")
-    private List<ItemHistory> itemhistories = new ArrayList<>();
-
-    public Item() {
-    }
-
-    public Item(User user,
-                String itemname,
-                String itemdescription,
-                String lentto,
-                String lentdate,
-                String lendnotes) {
-        this.user = user;
+    public ItemNoHistory(long itemid,
+                         String itemname,
+                         String itemdescription,
+                         String lentto,
+                         String lentdate,
+                         String lendnotes) {
+        this.itemid = itemid;
         this.itemname = itemname;
         this.itemdescription = itemdescription;
         this.lentto = lentto;
         this.lentdate = lentdate;
         this.lendnotes = lendnotes;
+        this.itemhistories = new ArrayList<>();
     }
 
     public long getItemid() {
@@ -99,14 +73,6 @@ public class Item extends Auditable {
 
     public void setLendnotes(String lendnotes) {
         this.lendnotes = lendnotes;
-    }
-
-    public User getUser() {
-        return user;
-    }
-
-    public void setUser(User user) {
-        this.user = user;
     }
 
     public List<ItemHistory> getItemhistories() {

--- a/src/main/java/com/zero5nelsonm/lendr/repository/ItemRepository.java
+++ b/src/main/java/com/zero5nelsonm/lendr/repository/ItemRepository.java
@@ -1,6 +1,8 @@
 package com.zero5nelsonm.lendr.repository;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.zero5nelsonm.lendr.model.Item;
+import com.zero5nelsonm.lendr.model.User;
 import com.zero5nelsonm.lendr.view.JustTheCount;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -13,6 +15,12 @@ public interface ItemRepository extends PagingAndSortingRepository<Item, Long> {
 
     @Query(value = "SELECT COUNT(*) as count FROM items WHERE userid = :userid AND itemname = :itemname",
             nativeQuery = true)
-    JustTheCount checkItemNameForUserExists(long userid, String itemname);
+    JustTheCount checkItemByNameForUserByIdExists(String itemname, long userid);
 
+    @Query(value = "SELECT COUNT(*) as count FROM items WHERE userid = :userid AND itemid = :itemid",
+            nativeQuery = true)
+    JustTheCount checkItemByIdForUserByIdExists(long itemid, long userid);
+
+    @Query(value = "SELECT * FROM items WHERE itemid = :itemid", nativeQuery = true)
+    Item findItemByItemid(long itemid);
 }

--- a/src/main/java/com/zero5nelsonm/lendr/service/ItemService.java
+++ b/src/main/java/com/zero5nelsonm/lendr/service/ItemService.java
@@ -12,4 +12,6 @@ public interface ItemService {
     Item findItemByIdForUser(User user, long itemid);
 
     Item save(Item item);
+
+    Item update(Item updateItem, long itemid, User user);
 }

--- a/src/main/java/com/zero5nelsonm/lendr/service/ItemService.java
+++ b/src/main/java/com/zero5nelsonm/lendr/service/ItemService.java
@@ -1,6 +1,7 @@
 package com.zero5nelsonm.lendr.service;
 
 import com.zero5nelsonm.lendr.model.Item;
+import com.zero5nelsonm.lendr.model.ItemHistory;
 import com.zero5nelsonm.lendr.model.User;
 
 import java.util.List;
@@ -16,4 +17,6 @@ public interface ItemService {
     Item update(Item updateItem, long itemid, User user);
 
     void delete(User user, long itemid);
+
+    Item itemHasBeenReturned(Item item, ItemHistory newItemHistory);
 }

--- a/src/main/java/com/zero5nelsonm/lendr/service/ItemService.java
+++ b/src/main/java/com/zero5nelsonm/lendr/service/ItemService.java
@@ -1,12 +1,15 @@
 package com.zero5nelsonm.lendr.service;
 
 import com.zero5nelsonm.lendr.model.Item;
+import com.zero5nelsonm.lendr.model.User;
 
 import java.util.List;
 
 public interface ItemService {
 
     List<Item> findAllByUsername(String username);
+
+    Item findItemByIdForUser(User user, long itemid);
 
     Item save(Item item);
 }

--- a/src/main/java/com/zero5nelsonm/lendr/service/ItemService.java
+++ b/src/main/java/com/zero5nelsonm/lendr/service/ItemService.java
@@ -14,4 +14,6 @@ public interface ItemService {
     Item save(Item item);
 
     Item update(Item updateItem, long itemid, User user);
+
+    void delete(User user, long itemid);
 }

--- a/src/main/java/com/zero5nelsonm/lendr/service/ItemServiceImpl.java
+++ b/src/main/java/com/zero5nelsonm/lendr/service/ItemServiceImpl.java
@@ -30,13 +30,13 @@ public class ItemServiceImpl implements ItemService {
 
     private void CheckItemByIdForUserByIdExists(long itemid, long userid) {
         if (itemRepository.checkItemByIdForUserByIdExists(itemid, userid).getCount() < 1) {
-            throw new ResourceNotFoundException("Item ID " + itemid + " does not exist for that user!");
+            throw new ResourceNotFoundException("Itemid " + itemid + " does not exist for that user!");
         }
     }
 
-    private void CheckItemByNameForUserByIdExists(Item item) {
-        if (itemRepository.checkItemByNameForUserByIdExists(item.getItemname(), item.getUser().getUserid()).getCount() > 0) {
-            throw new ResourceFoundException(item.getItemname() + " already exists!");
+    private void CheckItemByNameForUserByIdExists(Item item, long userid) {
+        if (itemRepository.checkItemByNameForUserByIdExists(item.getItemname(), userid).getCount() > 0) {
+            throw new ResourceFoundException("Itemname " + item.getItemname() + " already exists!");
         }
     }
 
@@ -57,7 +57,7 @@ public class ItemServiceImpl implements ItemService {
     @Override
     public Item save(Item item) {
 
-        CheckItemByNameForUserByIdExists(item);
+        CheckItemByNameForUserByIdExists(item, item.getUser().getUserid());
 
         return itemRepository.save(item);
     }
@@ -70,6 +70,7 @@ public class ItemServiceImpl implements ItemService {
         Item existingItem = itemRepository.findItemByItemid(itemid);
 
         if (updateItem.getItemname() != null) {
+            CheckItemByNameForUserByIdExists(updateItem, user.getUserid());
             existingItem.setItemname(updateItem.getItemname());
         }
 

--- a/src/main/java/com/zero5nelsonm/lendr/service/ItemServiceImpl.java
+++ b/src/main/java/com/zero5nelsonm/lendr/service/ItemServiceImpl.java
@@ -4,6 +4,7 @@ import com.zero5nelsonm.lendr.exceptions.ResourceFoundException;
 import com.zero5nelsonm.lendr.exceptions.ResourceNotFoundException;
 import com.zero5nelsonm.lendr.logging.Loggable;
 import com.zero5nelsonm.lendr.model.Item;
+import com.zero5nelsonm.lendr.model.ItemHistory;
 import com.zero5nelsonm.lendr.model.User;
 import com.zero5nelsonm.lendr.repository.ItemHistoryRepository;
 import com.zero5nelsonm.lendr.repository.ItemRepository;
@@ -50,5 +51,37 @@ public class ItemServiceImpl implements ItemService {
         }
 
         return itemRepository.save(item);
+    }
+
+    @Override
+    public Item update(Item updateItem, long itemid, User user) {
+
+        if (itemRepository.checkItemByIdForUserByIdExists(itemid, user.getUserid()).getCount() < 1) {
+            throw new ResourceNotFoundException("Item ID " + itemid + " does not exist for that user!");
+        }
+
+        Item existingItem = itemRepository.findItemByItemid(itemid);
+
+        if (updateItem.getItemname() != null) {
+            existingItem.setItemname(updateItem.getItemname());
+        }
+
+        if (updateItem.getItemdescription() != null) {
+            existingItem.setItemdescription(updateItem.getItemdescription());
+        }
+
+        if (updateItem.getLentto() != null) {
+            existingItem.setLentto(updateItem.getLentto());
+        }
+
+        if (updateItem.getLentdate() != null) {
+            existingItem.setLentdate(updateItem.getLentdate());
+        }
+
+        if (updateItem.getLendnotes() != null) {
+            existingItem.setLendnotes(updateItem.getLendnotes());
+        }
+
+        return itemRepository.save(existingItem);
     }
 }

--- a/src/main/java/com/zero5nelsonm/lendr/service/ItemServiceImpl.java
+++ b/src/main/java/com/zero5nelsonm/lendr/service/ItemServiceImpl.java
@@ -100,4 +100,15 @@ public class ItemServiceImpl implements ItemService {
 
         itemRepository.deleteById(itemid);
     }
+
+    @Override
+    public Item itemHasBeenReturned(Item item, ItemHistory newItemHistory) {
+        item.setLentto(null);
+        item.setLentdate(null);
+        item.setLendnotes(null);
+        itemRepository.save(item);
+        itemHistoryRepository.save(newItemHistory);
+
+        return itemRepository.findItemByItemid(item.getItemid());
+    }
 }

--- a/src/main/java/com/zero5nelsonm/lendr/service/ItemServiceImpl.java
+++ b/src/main/java/com/zero5nelsonm/lendr/service/ItemServiceImpl.java
@@ -1,15 +1,16 @@
 package com.zero5nelsonm.lendr.service;
 
 import com.zero5nelsonm.lendr.exceptions.ResourceFoundException;
+import com.zero5nelsonm.lendr.exceptions.ResourceNotFoundException;
 import com.zero5nelsonm.lendr.logging.Loggable;
 import com.zero5nelsonm.lendr.model.Item;
 import com.zero5nelsonm.lendr.model.User;
+import com.zero5nelsonm.lendr.repository.ItemHistoryRepository;
 import com.zero5nelsonm.lendr.repository.ItemRepository;
 import com.zero5nelsonm.lendr.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Loggable
@@ -22,6 +23,9 @@ public class ItemServiceImpl implements ItemService {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private ItemHistoryRepository itemHistoryRepository;
+
     @Override
     public List<Item> findAllByUsername(String username) {
 
@@ -29,9 +33,19 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Override
+    public Item findItemByIdForUser(User user, long itemid) {
+
+        if (itemRepository.checkItemByIdForUserByIdExists(itemid, user.getUserid()).getCount() < 1) {
+            throw new ResourceNotFoundException("Item ID " + itemid + " does not exist for that user!");
+        }
+
+        return itemRepository.findItemByItemid(itemid);
+    }
+
+    @Override
     public Item save(Item item) {
 
-        if (itemRepository.checkItemNameForUserExists(item.getUser().getUserid(), item.getItemname()).getCount() > 0) {
+        if (itemRepository.checkItemByNameForUserByIdExists(item.getItemname(), item.getUser().getUserid()).getCount() > 0) {
             throw new ResourceFoundException(item.getItemname() + " already exists!");
         }
 

--- a/src/main/java/com/zero5nelsonm/lendr/service/ItemServiceImpl.java
+++ b/src/main/java/com/zero5nelsonm/lendr/service/ItemServiceImpl.java
@@ -1,5 +1,6 @@
 package com.zero5nelsonm.lendr.service;
 
+import com.sun.istack.Nullable;
 import com.zero5nelsonm.lendr.exceptions.ResourceFoundException;
 import com.zero5nelsonm.lendr.exceptions.ResourceNotFoundException;
 import com.zero5nelsonm.lendr.logging.Loggable;
@@ -27,6 +28,18 @@ public class ItemServiceImpl implements ItemService {
     @Autowired
     private ItemHistoryRepository itemHistoryRepository;
 
+    private void CheckItemByIdForUserByIdExists(long itemid, long userid) {
+        if (itemRepository.checkItemByIdForUserByIdExists(itemid, userid).getCount() < 1) {
+            throw new ResourceNotFoundException("Item ID " + itemid + " does not exist for that user!");
+        }
+    }
+
+    private void CheckItemByNameForUserByIdExists(Item item) {
+        if (itemRepository.checkItemByNameForUserByIdExists(item.getItemname(), item.getUser().getUserid()).getCount() > 0) {
+            throw new ResourceFoundException(item.getItemname() + " already exists!");
+        }
+    }
+
     @Override
     public List<Item> findAllByUsername(String username) {
 
@@ -36,9 +49,7 @@ public class ItemServiceImpl implements ItemService {
     @Override
     public Item findItemByIdForUser(User user, long itemid) {
 
-        if (itemRepository.checkItemByIdForUserByIdExists(itemid, user.getUserid()).getCount() < 1) {
-            throw new ResourceNotFoundException("Item ID " + itemid + " does not exist for that user!");
-        }
+        CheckItemByIdForUserByIdExists(itemid, user.getUserid());
 
         return itemRepository.findItemByItemid(itemid);
     }
@@ -46,9 +57,7 @@ public class ItemServiceImpl implements ItemService {
     @Override
     public Item save(Item item) {
 
-        if (itemRepository.checkItemByNameForUserByIdExists(item.getItemname(), item.getUser().getUserid()).getCount() > 0) {
-            throw new ResourceFoundException(item.getItemname() + " already exists!");
-        }
+        CheckItemByNameForUserByIdExists(item);
 
         return itemRepository.save(item);
     }
@@ -56,9 +65,7 @@ public class ItemServiceImpl implements ItemService {
     @Override
     public Item update(Item updateItem, long itemid, User user) {
 
-        if (itemRepository.checkItemByIdForUserByIdExists(itemid, user.getUserid()).getCount() < 1) {
-            throw new ResourceNotFoundException("Item ID " + itemid + " does not exist for that user!");
-        }
+        CheckItemByIdForUserByIdExists(itemid, user.getUserid());
 
         Item existingItem = itemRepository.findItemByItemid(itemid);
 
@@ -83,5 +90,13 @@ public class ItemServiceImpl implements ItemService {
         }
 
         return itemRepository.save(existingItem);
+    }
+
+    @Override
+    public void delete(User user, long itemid) {
+
+        CheckItemByIdForUserByIdExists(itemid, user.getUserid());
+
+        itemRepository.deleteById(itemid);
     }
 }


### PR DESCRIPTION
This PR adds further capability to endpoints such that a user can now:

query a single item.
update an item.
delete an item.
query a list of all items and choose to include with that list, the item history.
mark an item as returned.